### PR TITLE
psu name correction

### DIFF
--- a/index.html
+++ b/index.html
@@ -252,8 +252,8 @@
         <div class="credits-group-sub" data-text="Founded At">
           Founded At
         </div>
-        <div class="credits-group-credit" data-text="Pennsylvania State University">
-          Pennsylvania State University
+        <div class="credits-group-credit" data-text="The Pennsylvania State University">
+          The Pennsylvania State University
         </div>
       </div>
       <div class="credits-final">


### PR DESCRIPTION
Correct usage is "The Pennsylvania State University" or "Penn State University"